### PR TITLE
Don't save blank certificates/keys to Redis

### DIFF
--- a/app/models/lets_encrypt/certificate.rb
+++ b/app/models/lets_encrypt/certificate.rb
@@ -33,7 +33,7 @@ module LetsEncrypt
     scope :expired, -> { where('expires_at <= ?', Time.zone.now) }
 
     before_create -> { self.key = OpenSSL::PKey::RSA.new(4096).to_s }
-    after_save -> { save_to_redis }, if: -> { LetsEncrypt.config.use_redis? }
+    after_save -> { save_to_redis }, if: -> { LetsEncrypt.config.use_redis? && active? }
 
     # Returns false if certificate is not issued.
     #

--- a/lib/letsencrypt/redis.rb
+++ b/lib/letsencrypt/redis.rb
@@ -10,6 +10,7 @@ module LetsEncrypt
 
       # Save certificate into redis.
       def save(cert)
+        return unless cert.key.present? && cert.certificate.present?
         LetsEncrypt.logger.info "Save #{cert.domain}'s certificate to redis"
         connection.set "#{cert.domain}.key", cert.key
         connection.set "#{cert.domain}.crt", cert.certificate

--- a/spec/letsencrypt/redis_spec.rb
+++ b/spec/letsencrypt/redis_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails-letsencrypt'
+require 'rails_helper'
 
 RSpec.describe LetsEncrypt::Redis do
   let(:redis) { double(::Redis) }
@@ -15,8 +15,16 @@ RSpec.describe LetsEncrypt::Redis do
 
   describe '#save' do
     it 'saves certificate into redis' do
+      certificate.key = "KEY"
+      certificate.certificate = "CERTIFICATE"
       expect(redis).to receive(:set).with("#{domain}.key", an_instance_of(String))
       expect(redis).to receive(:set).with("#{domain}.crt", an_instance_of(String))
+      LetsEncrypt::Redis.save(certificate)
+    end
+
+    it 'doesnt save blank certificate into redis' do
+      expect(redis).to_not receive(:set).with("#{domain}.key", an_instance_of(String))
+      expect(redis).to_not receive(:set).with("#{domain}.crt", an_instance_of(String))
       LetsEncrypt::Redis.save(certificate)
     end
   end

--- a/spec/models/lets_encrypt/certificate_spec.rb
+++ b/spec/models/lets_encrypt/certificate_spec.rb
@@ -33,10 +33,19 @@ RSpec.describe LetsEncrypt::Certificate do
   end
 
   describe '#save_to_redis' do
-    it 'save certificate into redis' do
+    it 'doesnt save certificate if it is blank' do
+      expect(LetsEncrypt::Redis).to_not receive(:save)
+      LetsEncrypt.config.save_to_redis = true
+      subject.domain = 'example.com'
+      subject.save
+    end
+
+    it 'saves certificate into redis' do
       expect(LetsEncrypt::Redis).to receive(:save)
       LetsEncrypt.config.save_to_redis = true
       subject.domain = 'example.com'
+      subject.certificate = 'CERTIFICATE'
+      subject.key = 'KEY'
       subject.save
     end
   end


### PR DESCRIPTION
I am using this code to check for certificates and keys in Redis:

```ruby
LetsEncrypt::Redis.connection.exists("#{domain}.crt") && LetsEncrypt::Redis.connection.exists("#{domain}.key")
```

(I want to use `exists`, because it's much faster than a `get` that returns the whole certificate.)

`rails-letsencrypt` was saving blank strings into Redis as soon as the `LetsEncrypt::Certificate` model was created, which broke this code. (Because an empty string returns `true` for the call to `exists`.) 

This behavior also broke the code in my nginx mruby script:

```
    if redis["#{domain}.crt"] && redis["#{domain}.key"]
      ssl.certificate_data = redis["#{domain}.crt"]
      ssl.certificate_key_data = redis["#{domain}.key"]
    end
```

(I'm going to update it to check for empty strings.)
