### PR TITLE
Add certificate_model to Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ LetsEncrypt.config do |config|
   # The redis server url
   # Default is nil
   config.redis_url = 'redis://localhost:6379/1'
+
+  # Enable it if you want to customize the model
+  # Default is LetsEncrypt::Certificate
+  #config.certificate_model = 'MyCertificate'
 end
 ```
 

--- a/app/controllers/lets_encrypt/verifications_controller.rb
+++ b/app/controllers/lets_encrypt/verifications_controller.rb
@@ -17,7 +17,7 @@ module LetsEncrypt
     end
 
     def certificate
-      LetsEncrypt::Certificate.find_by(verification_path: filename)
+      LetsEncrypt.config.certificate_model.constantize.find_by(verification_path: filename)
     end
 
     def filename

--- a/app/controllers/lets_encrypt/verifications_controller.rb
+++ b/app/controllers/lets_encrypt/verifications_controller.rb
@@ -17,7 +17,7 @@ module LetsEncrypt
     end
 
     def certificate
-      LetsEncrypt.config.certificate_model.constantize.find_by(verification_path: filename)
+      LetsEncrypt.certificate_model.find_by(verification_path: filename)
     end
 
     def filename

--- a/app/jobs/lets_encrypt/renew_certificates_job.rb
+++ b/app/jobs/lets_encrypt/renew_certificates_job.rb
@@ -6,7 +6,7 @@ module LetsEncrypt
     queue_as :default
 
     def perform
-      LetsEncrypt.config.certificate_model.constantize.renewable.each do |certificate|
+      LetsEncrypt.certificate_model.renewable.each do |certificate|
         next if certificate.renew
         certificate.update(renew_after: 1.day.from_now)
       end

--- a/app/jobs/lets_encrypt/renew_certificates_job.rb
+++ b/app/jobs/lets_encrypt/renew_certificates_job.rb
@@ -6,7 +6,7 @@ module LetsEncrypt
     queue_as :default
 
     def perform
-      LetsEncrypt::Certificate.renewable.each do |certificate|
+      LetsEncrypt.config.certificate_model.constantize.renewable.each do |certificate|
         next if certificate.renew
         certificate.update(renew_after: 1.day.from_now)
       end

--- a/lib/letsencrypt.rb
+++ b/lib/letsencrypt.rb
@@ -86,5 +86,9 @@ module LetsEncrypt
     def table_name_prefix
       'letsencrypt_'
     end
+
+    def certificate_model
+      config.certificate_model.constantize
+    end
   end
 end

--- a/lib/letsencrypt.rb
+++ b/lib/letsencrypt.rb
@@ -88,7 +88,7 @@ module LetsEncrypt
     end
 
     def certificate_model
-      config.certificate_model.constantize
+      @certificate_model ||= config.certificate_model.constantize
     end
   end
 end

--- a/lib/letsencrypt/configuration.rb
+++ b/lib/letsencrypt/configuration.rb
@@ -16,6 +16,10 @@ module LetsEncrypt
     config_accessor :save_to_redis
     config_accessor :redis_url
 
+    config_accessor :certificate_model do
+      'LetsEncrypt::Certificate'
+    end
+
     # Returns true if enabled `save_to_redis` feature
     def use_redis?
       save_to_redis == true

--- a/lib/tasks/letsencrypt_tasks.rake
+++ b/lib/tasks/letsencrypt_tasks.rake
@@ -5,7 +5,7 @@ namespace :letsencrypt do
   task renew: :environment do
     count = 0
     failed = 0
-    LetsEncrypt::Certificate.renewable do |certificate|
+    LetsEncrypt.config.certificate_model.constantize.renewable do |certificate|
       count += 1
       next if certificate.renew
       failed += 1

--- a/lib/tasks/letsencrypt_tasks.rake
+++ b/lib/tasks/letsencrypt_tasks.rake
@@ -5,7 +5,7 @@ namespace :letsencrypt do
   task renew: :environment do
     count = 0
     failed = 0
-    LetsEncrypt.config.certificate_model.constantize.renewable do |certificate|
+    LetsEncrypt.certificate_model.renewable do |certificate|
       count += 1
       next if certificate.renew
       failed += 1

--- a/spec/controllers/lets_encrypt/verifications_controller_spec.rb
+++ b/spec/controllers/lets_encrypt/verifications_controller_spec.rb
@@ -6,28 +6,40 @@ RSpec.describe LetsEncrypt::VerificationsController, type: :controller do
   routes { LetsEncrypt::Engine.routes }
   class OtherModel < LetsEncrypt::Certificate
   end
-  before(:each) do
-    LetsEncrypt.config.certificate_model = 'OtherModel'
-  end
 
   it 'returns 404 status when no valid verification path found' do
     open(:get, :show, verification_path: :invalid_path)
     expect(response.status).to eq(404)
   end
 
-  context 'has certificate' do
-    let!(:certificate) do
+
+  describe 'has certificate' do
+   let!(:certificate) do
       LetsEncrypt.certificate_model.create(
         domain: 'example.com',
         verification_path: '.well-known/acme-challenge/valid_path',
         verification_string: 'verification'
       )
     end
+    context 'with default model' do
+      it 'returns verification string when found verification path' do
+        open(:get, :show, verification_path: 'valid_path')
+        expect(response.status).to eq(200)
+        expect(response.body).to eq(certificate.verification_string)
+      end
+    end
 
-    it 'returns verification string when found verification path' do
-      open(:get, :show, verification_path: 'valid_path')
-      expect(response.status).to eq(200)
-      expect(response.body).to eq(certificate.verification_string)
+    context 'with customize model' do
+      LetsEncrypt.config.certificate_model = 'OtherModel'
+      it 'set the certificate_model to customize model' do
+        expect(LetsEncrypt.certificate_model).to eq('OtherModel'.constantize)
+      end
+
+      it 'returns verification string when found verification path' do
+        open(:get, :show, verification_path: 'valid_path')
+        expect(response.status).to eq(200)
+        expect(response.body).to eq(certificate.verification_string)
+      end
     end
   end
 end

--- a/spec/controllers/lets_encrypt/verifications_controller_spec.rb
+++ b/spec/controllers/lets_encrypt/verifications_controller_spec.rb
@@ -10,16 +10,14 @@ RSpec.describe LetsEncrypt::VerificationsController, type: :controller do
     LetsEncrypt.config.certificate_model = 'OtherModel'
   end
 
-  context 'has certificate' do
-    it 'returns 404 status when no valid verification path found' do
-      open(:get, :show, verification_path: :invalid_path)
-      expect(response.status).to eq(404)
-    end
+  it 'returns 404 status when no valid verification path found' do
+    open(:get, :show, verification_path: :invalid_path)
+    expect(response.status).to eq(404)
   end
 
   context 'has certificate' do
     let!(:certificate) do
-      LetsEncrypt.config.certificate_model.constantize.create(
+      LetsEncrypt.certificate_model.create(
         domain: 'example.com',
         verification_path: '.well-known/acme-challenge/valid_path',
         verification_string: 'verification'

--- a/spec/controllers/lets_encrypt/verifications_controller_spec.rb
+++ b/spec/controllers/lets_encrypt/verifications_controller_spec.rb
@@ -30,11 +30,8 @@ RSpec.describe LetsEncrypt::VerificationsController, type: :controller do
     end
 
     context 'with customize model' do
-      LetsEncrypt.config.certificate_model = 'OtherModel'
-      it 'set the certificate_model to customize model' do
-        expect(LetsEncrypt.certificate_model).to eq('OtherModel'.constantize)
-      end
-
+      before { LetsEncrypt.config.certificate_model = 'OtherModel' }
+      after { LetsEncrypt.config.certificate_model = 'LetsEncrypt::Certificate' }
       it 'returns verification string when found verification path' do
         open(:get, :show, verification_path: 'valid_path')
         expect(response.status).to eq(200)

--- a/spec/controllers/lets_encrypt/verifications_controller_spec.rb
+++ b/spec/controllers/lets_encrypt/verifications_controller_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe LetsEncrypt::VerificationsController, type: :controller do
 
 
   describe 'has certificate' do
-   let!(:certificate) do
-      LetsEncrypt.certificate_model.create(
-        domain: 'example.com',
-        verification_path: '.well-known/acme-challenge/valid_path',
-        verification_string: 'verification'
-      )
-    end
     context 'with default model' do
+      let!(:certificate) do
+        LetsEncrypt.certificate_model.create(
+          domain: 'example.com',
+          verification_path: '.well-known/acme-challenge/valid_path',
+          verification_string: 'verification'
+        )
+      end
       it 'returns verification string when found verification path' do
         open(:get, :show, verification_path: 'valid_path')
         expect(response.status).to eq(200)
@@ -31,6 +31,13 @@ RSpec.describe LetsEncrypt::VerificationsController, type: :controller do
 
     context 'with customize model' do
       before { LetsEncrypt.config.certificate_model = 'OtherModel' }
+      let!(:certificate) do
+        LetsEncrypt.certificate_model.create(
+          domain: 'example.com',
+          verification_path: '.well-known/acme-challenge/valid_path',
+          verification_string: 'verification'
+        )
+      end
       after { LetsEncrypt.config.certificate_model = 'LetsEncrypt::Certificate' }
       it 'returns verification string when found verification path' do
         open(:get, :show, verification_path: 'valid_path')

--- a/spec/controllers/lets_encrypt/verifications_controller_spec.rb
+++ b/spec/controllers/lets_encrypt/verifications_controller_spec.rb
@@ -4,15 +4,22 @@ require 'rails_helper'
 
 RSpec.describe LetsEncrypt::VerificationsController, type: :controller do
   routes { LetsEncrypt::Engine.routes }
+  class OtherModel < LetsEncrypt::Certificate
+  end
+  before(:each) do
+    LetsEncrypt.config.certificate_model = 'OtherModel'
+  end
 
-  it 'returns 404 status when no valid verification path found' do
-    open(:get, :show, verification_path: :invalid_path)
-    expect(response.status).to eq(404)
+  context 'has certificate' do
+    it 'returns 404 status when no valid verification path found' do
+      open(:get, :show, verification_path: :invalid_path)
+      expect(response.status).to eq(404)
+    end
   end
 
   context 'has certificate' do
     let!(:certificate) do
-      LetsEncrypt::Certificate.create(
+      LetsEncrypt.config.certificate_model.constantize.create(
         domain: 'example.com',
         verification_path: '.well-known/acme-challenge/valid_path',
         verification_string: 'verification'

--- a/spec/letsencrypt/configuration_spec.rb
+++ b/spec/letsencrypt/configuration_spec.rb
@@ -16,4 +16,28 @@ RSpec.describe LetsEncrypt::Configuration do
       expect(subject.use_staging?).to eq(subject.use_staging)
     end
   end
+
+  describe 'customize certificate model' do
+    class OtherModel < LetsEncrypt::Certificate
+      after_update :success
+
+      def success
+        'success'
+      end
+    end
+
+    before(:each) do
+      LetsEncrypt.config.certificate_model = 'OtherModel'
+      LetsEncrypt.certificate_model.create(
+        domain: 'example.com',
+        verification_path: '.well-known/acme-challenge/valid_path',
+        verification_string: 'verification'
+      )
+    end
+
+    it 'update data' do
+      expect_any_instance_of(OtherModel).to receive(:success)
+      LetsEncrypt.certificate_model.first.update(renew_after: 3.days.ago)
+    end
+  end
 end

--- a/spec/letsencrypt/configuration_spec.rb
+++ b/spec/letsencrypt/configuration_spec.rb
@@ -28,13 +28,14 @@ RSpec.describe LetsEncrypt::Configuration do
 
     before(:each) do
       LetsEncrypt.config.certificate_model = 'OtherModel'
+      LetsEncrypt.stub(:certificate_model) { 'OtherModel'.constantize }
       LetsEncrypt.certificate_model.create(
         domain: 'example.com',
         verification_path: '.well-known/acme-challenge/valid_path',
         verification_string: 'verification'
       )
     end
-
+    after { LetsEncrypt.config.certificate_model = 'LetsEncrypt::Certificate' }
     it 'update data' do
       expect_any_instance_of(OtherModel).to receive(:success)
       LetsEncrypt.certificate_model.first.update(renew_after: 3.days.ago)

--- a/spec/letsencrypt_spec.rb
+++ b/spec/letsencrypt_spec.rb
@@ -37,4 +37,14 @@ RSpec.describe LetsEncrypt do
       LetsEncrypt.register('example@example.com')
     end
   end
+
+  describe 'certificate_model' do
+    class OtherModel < LetsEncrypt::Certificate
+    end
+    before { LetsEncrypt.config.certificate_model = 'OtherModel' }
+    after { LetsEncrypt.config.certificate_model = 'LetsEncrypt::Certificate' }
+    it 'set the certificate_model to customize model' do
+        expect(LetsEncrypt.certificate_model).to eq('OtherModel'.constantize)
+    end
+  end
 end

--- a/spec/letsencrypt_spec.rb
+++ b/spec/letsencrypt_spec.rb
@@ -41,10 +41,13 @@ RSpec.describe LetsEncrypt do
   describe 'certificate_model' do
     class OtherModel < LetsEncrypt::Certificate
     end
-    before { LetsEncrypt.config.certificate_model = 'OtherModel' }
+    before do
+      LetsEncrypt.config.certificate_model = 'OtherModel'
+      LetsEncrypt.stub(:certificate_model) { LetsEncrypt.config.certificate_model.constantize }
+    end
     after { LetsEncrypt.config.certificate_model = 'LetsEncrypt::Certificate' }
     it 'set the certificate_model to customize model' do
-        expect(LetsEncrypt.certificate_model).to eq('OtherModel'.constantize)
+      expect(LetsEncrypt.certificate_model).to eq('OtherModel'.constantize)
     end
   end
 end


### PR DESCRIPTION
- Add certificate_model for user to customize model
- Replace LetsEncrypt::Certificate to LetsEncrypt.config.certificate_model.constantize
- Update README
https://github.com/elct9620/rails-letsencrypt/issues/14?fbclid=IwAR02rN3x6sw1KdrUzYkfYEYqmIfPQtsNys7x7BmVzb1SpwWPyKxR4ljINOg