### PR TITLE
Fix letsencrypt:renew rake task to actually iterate over certs

### DIFF
--- a/lib/tasks/letsencrypt_tasks.rake
+++ b/lib/tasks/letsencrypt_tasks.rake
@@ -5,7 +5,7 @@ namespace :letsencrypt do
   task renew: :environment do
     count = 0
     failed = 0
-    LetsEncrypt.certificate_model.renewable do |certificate|
+    LetsEncrypt.certificate_model.renewable.each do |certificate|
       count += 1
       next if certificate.renew
       failed += 1


### PR DESCRIPTION
Adds missing `.each` 