### PR TITLE
Fix logging error from rake renew task with minor text changes

### DIFF
--- a/lib/tasks/letsencrypt_tasks.rake
+++ b/lib/tasks/letsencrypt_tasks.rake
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
 namespace :letsencrypt do
-  desc 'Renew the certificates will epxired'
+  desc "Renew certificates that already expired or expiring soon"
   task renew: :environment do
     count = 0
     failed = 0
+
     LetsEncrypt.certificate_model.renewable.each do |certificate|
       count += 1
+
       next if certificate.renew
+
       failed += 1
-      log "Could not renew domain: #{certificate.domain}"
+      puts "Could not renew domain: #{certificate.domain}"
     end
 
-    puts "Total #{count} domains should renew, and #{failed} domains cannot be renewed."
+    puts "Renewed #{count - failed} out of #{count} domains"
   end
 end


### PR DESCRIPTION
Hi @elct9620, thanks for your gem :)

I was wondering about using LetsEncrypt.logger instead, but thought this would be the simplest patch