### PR TITLE
Save bundle into Redis instead of certificate

### DIFF
--- a/app/models/lets_encrypt/certificate.rb
+++ b/app/models/lets_encrypt/certificate.rb
@@ -57,7 +57,7 @@ module LetsEncrypt
 
     # Returns full-chain bundled certificates
     def bundle
-      certificate + intermediaries
+      (certificate || '') + (intermediaries || '')
     end
 
     def certificate_object

--- a/lib/letsencrypt/redis.rb
+++ b/lib/letsencrypt/redis.rb
@@ -10,10 +10,10 @@ module LetsEncrypt
 
       # Save certificate into redis.
       def save(cert)
-        return unless cert.key.present? && cert.certificate.present?
-        LetsEncrypt.logger.info "Save #{cert.domain}'s certificate to redis"
+        return unless cert.key.present? && cert.bundle.present?
+        LetsEncrypt.logger.info "Save #{cert.domain}'s certificate (bundle) to redis"
         connection.set "#{cert.domain}.key", cert.key
-        connection.set "#{cert.domain}.crt", cert.certificate
+        connection.set "#{cert.domain}.crt", cert.bundle
       end
     end
   end


### PR DESCRIPTION
Closes #16 

Right now the library saves only certificate into Redis. The best practice these days is to provide a bundle instead. I tried both options and when I use certificate-only SSLabs complains about missing bundle and decreases rate to B. When I use bundle it's possible to get A+.

Here's an example of the domain using this library with the bundled certificate: https://www.ssllabs.com/ssltest/analyze.html?d=bleakandsleek.com

I suggest making the bundle a default. It's also might be a good idea to create a config option to toggle between bundle and certificate-only. @elct9620 what do you think?