### PR TITLE
Typo in certificate verifiable error

### DIFF
--- a/app/models/concerns/lets_encrypt/certificate_verifiable.rb
+++ b/app/models/concerns/lets_encrypt/certificate_verifiable.rb
@@ -60,7 +60,7 @@ module LetsEncrypt
         sleep 1
         verify
       else
-        logger.info "#{domain}: Error: #{e.class} (#{e.message})"
+        logger.info "#{domain}: Error: #{error.class} (#{error.message})"
         false
       end
     end


### PR DESCRIPTION
As you can see, the variable "e" doesn't exists ;)